### PR TITLE
Refactor environment variable rendering/location.

### DIFF
--- a/charm/reactive/javan_rhino.py
+++ b/charm/reactive/javan_rhino.py
@@ -22,8 +22,6 @@ def configure(cache):
     environment = hookenv.config('environment')
     session_secret = hookenv.config('session_secret')
     memcache_session_secret = hookenv.config('memcache_session_secret')
-    sentry_dsn = hookenv.config('sentry_dsn')
-    statsd_dsn = hookenv.config('statsd_dsn')
     if session_secret and memcache_session_secret:
         render(source='javan-rhino_env.j2',
                target=env_file,
@@ -41,8 +39,6 @@ def configure(cache):
                 'environment': environment,
                 'cache_hosts': sorted(cache.memcache_hosts()),
                 'memcache_session_secret': memcache_session_secret,
-                'sentry_dsn': sentry_dsn,
-                'statsd_dsn': statsd_dsn,
             })
         check_port('ols.{}.express'.format(service_name()), port())
         set_state('service.configured')

--- a/charm/templates/javan-rhino_systemd.j2
+++ b/charm/templates/javan-rhino_systemd.j2
@@ -6,10 +6,6 @@ Description=Front-end to Ubuntu Store Payments
 
 [Service]
 Type=simple
-Environment='SESSION_SECRET={{ session_secret }}'
-Environment='SERVER__LOGS_PATH={{ logs_path }}'
-Environment='SESSION_MEMCACHED_HOST={{ cache_hosts | join(",") }}'
-Environment='SESSION_MEMCACHED_SECRET={{ memcache_session_secret }}'
 {% if env_file %}
 EnvironmentFile={{ env_file }}
 {% endif %}

--- a/charm/templates/javan-rhino_systemd.j2
+++ b/charm/templates/javan-rhino_systemd.j2
@@ -10,8 +10,6 @@ Environment='SESSION_SECRET={{ session_secret }}'
 Environment='SERVER__LOGS_PATH={{ logs_path }}'
 Environment='SESSION_MEMCACHED_HOST={{ cache_hosts | join(",") }}'
 Environment='SESSION_MEMCACHED_SECRET={{ memcache_session_secret }}'
-Environment='SENTRY_DSN={{ sentry_dsn }}'
-Environment='STATSD_DSN={{ statsd_dsn }}'
 {% if env_file %}
 EnvironmentFile={{ env_file }}
 {% endif %}


### PR DESCRIPTION
All the environment variables, even the service-specific ones, are now rendered to the service's etc/environment_variables file. The systemd unit is now variable-free. 