### PR TITLE
Add interface-prometheus as explicit charm dep

### DIFF
--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -6,6 +6,7 @@ interface/interface-juju-info       lp:~ubuntuone-hackers/ols-charm-deps/interfa
 interface/interface-memcache        git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/interface-memcache;revno=5ccddd9
 interface/interface-pgsql           git+ssh://git.launchpad.net/interface-pgsql;revno=1c6e893
 interface/interface-wsgi            git+ssh://git.launchpad.net/~ubuntuone-hackers/charms/+source/interface-wsgi;revno=04cab5b
+interface/interface-prometheus      lp:~ubuntuone-hackers/ols-charm-deps/juju-interface-prometheus;revno=1
 
 layer                               @
 layer/layer-apt                     git+ssh://git.launchpad.net/layer-apt;revno=36f956aa97


### PR DESCRIPTION
Should fix the breakage introduced in 9b3988f2 where I naively upgraded all the layers without noticing this extra dependency.