### PR TITLE
Reload systemd units

### DIFF
--- a/charm/reactive/javan_rhino.py
+++ b/charm/reactive/javan_rhino.py
@@ -8,11 +8,20 @@ from charmhelpers.core.host import restart_on_change
 from charmhelpers.core.templating import render
 from charms.reactive import when, when_not, set_state
 from charms.apt import queue_install
-from ols.base import check_port, code_dir, env_vars, etc_dir, logs_dir, service_name, user
+from ols.base import (
+        check_port,
+        code_dir,
+        env_vars,
+        etc_dir,
+        logs_dir,
+        service_name,
+        user
+)
 from ols.http import port
 
 
 SYSTEMD_CONFIG = '/lib/systemd/system/javan-rhino.service'
+
 
 @when('cache.available')
 @when('ols.service.installed')
@@ -28,13 +37,13 @@ def configure(cache):
                 'SERVER__LOGS_PATH': logs_dir(),
                 'SESSION_SECRET': session_secret,
                 'SESSION_MEMCACHED_SECRET': memcache_session_secret,
-                'SESSION_MEMCACHED_HOST': ",".join(sorted(cache.memcache_hosts())),
+                'SESSION_MEMCACHED_HOST': ",".join(
+                    sorted(cache.memcache_hosts())),
                 }
         env_extra.update(additional_vars)
         render(source='javan-rhino_env.j2',
                target=env_file,
-               context={'env_extra': sorted(env_extra.items())}
-        )
+               context={'env_extra': sorted(env_extra.items())})
         render(
             source='javan-rhino_systemd.j2',
             target=SYSTEMD_CONFIG,
@@ -68,14 +77,15 @@ def install_custom_nodejs():
         installed_version_output = check_output('dpkg -s nodejs || exit 0',
                                                 shell=True)
         installed = search('Version: (.*)',
-                            installed_version_output.decode('ascii'))
+                           installed_version_output.decode('ascii'))
         installed_version = installed.groups()[0] if installed else ''
 
         if installed_version.strip() != deb_pkg_version.groups()[0].strip():
             hookenv.log('Installed NodeJS {} != {}, installing from custom deb'
                         .format(installed_version,  deb_pkg_version))
             hookenv.status_set('maintenance', 'Installing {}'.format(deb_path))
-            check_call(['apt', 'install', '-y', '--allow-downgrades', deb_path])
+            check_call(
+                ['apt', 'install', '-y', '--allow-downgrades', deb_path])
             hookenv.status_set('active', 'Custom NodeJs package installed')
     else:
         # Although it would be nice to let the apt layer handle all this for

--- a/charm/reactive/javan_rhino.py
+++ b/charm/reactive/javan_rhino.py
@@ -1,6 +1,6 @@
 from glob import glob
 from re import search
-from os.path import dirname, join
+from os.path import basename, dirname, join
 from subprocess import check_call, check_output
 
 from charmhelpers.core import hookenv
@@ -44,6 +44,8 @@ def configure(cache):
                 'env_file': env_file,
                 'environment': environment,
             })
+        check_call(['systemctl', 'enable', basename(SYSTEMD_CONFIG)])
+        check_call(['systemctl', 'daemon-reload'])
         check_port('ols.{}.express'.format(service_name()), port())
         set_state('service.configured')
         hookenv.status_set('active', 'systemd unit configured')


### PR DESCRIPTION
When the config changes, it's not really applied (even if systemctl restarting the service) unless systemd is told to reload the units. This fixes that by enabling the service (just in case) and reloading units.