### PR TITLE
Bump layer-ols-http to r11 to avoid invalid nagios descriptions

### DIFF
--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -12,6 +12,6 @@ layer                               @
 layer/layer-apt                     git+ssh://git.launchpad.net/layer-apt;revno=36f956aa97
 layer/layer-basic                   lp:~ubuntuone-hackers/ols-charm-deps/layer-basic;revno=68
 layer/layer-ols                     lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols;revno=17
-layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=7
+layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=11
 
 wheels                              git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/wheels


### PR DESCRIPTION
This is needed because the layer in question was building nagios descriptions like:

javan-rhino server (staging)

While parentheses are invalid in nagios descriptions. The new version of the layer properly omits invalid characters.