### PR TITLE
Write logfile to a specific file.

### DIFF
--- a/charm/layer.yaml
+++ b/charm/layer.yaml
@@ -8,6 +8,8 @@ options:
         service_name: javan-rhino
         user: ubuntu
         tarball_payload: false
+        logs:
+            "/var/log/javan-rhino.log": {type: 'talisker'}
 
 exclude:
     - tmp

--- a/charm/templates/javan-rhino_logrotate.tmpl
+++ b/charm/templates/javan-rhino_logrotate.tmpl
@@ -1,0 +1,13 @@
+{{ logfile }}
+{
+	rotate 7
+	daily
+	missingok
+	notifempty
+	delaycompress
+	compress
+	postrotate
+		invoke-rc.d rsyslog rotate > /dev/null
+	endscript
+}
+

--- a/charm/templates/javan-rhino_syslog.tmpl
+++ b/charm/templates/javan-rhino_syslog.tmpl
@@ -1,0 +1,8 @@
+template(name="talisker" type="list") {
+    property(name="msg" position.from="2")
+    constant(value="\n")
+}
+
+if $programname == 'talisker' or $programname == "npm" then {
+action(type="omfile" file="{{ logfile }}" template="talisker")
+}


### PR DESCRIPTION
This is needed so we can then point logstash-forwarder to that file.

It also adds a logrotate config file and keeps 1 week of logs (should
be enough since we're stashing them away in ELK).