### PR TITLE
Set npm "save" behavior to false.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+install:
+  - npm set save false
+  - npm install
 node_js:
   - "6"
   - "node"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start-build": "node dist/server/",
     "build": "./scripts/build.sh",
     "lint": "eslint -c .eslintrc.js '**/*.js'",
+    "pretest": "npm set save false",
     "test": "nyc npm run test:run && npm run lint",
     "test:run": "npm run test:unit && npm run test:routes",
     "test:unit": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha --recursive --require babel-core/register --compilers js:babel-register ./test/unit/setup.js ./test/unit/t_*.js ./test/unit/**/*",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "start-build": "node dist/server/",
     "build": "./scripts/build.sh",
     "lint": "eslint -c .eslintrc.js '**/*.js'",
-    "pretest": "npm set save false",
     "test": "nyc npm run test:run && npm run lint",
     "test:run": "npm run test:unit && npm run test:routes",
     "test:unit": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha --recursive --require babel-core/register --compilers js:babel-register ./test/unit/setup.js ./test/unit/t_*.js ./test/unit/**/*",


### PR DESCRIPTION
npm 8.x defaults to save=true, which causes the shipped shrinkwrap.json
to be rewritten, causing our sanity tests to fail in turn.

Since both 8.x and 6.x honor the "save" setting, set it to "false"
(which is the default in npm 6.x) to get consistent behavior.

Should fix https://travis-ci.org/canonical-ols/my.ubuntu.com/jobs/247165132 Travis run errors.