### PR TITLE
Set git username and email for pushing charm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,7 @@ git-build: EXTRA_CHARM_BUILD_ARGS = --force
 git-build: build $(GIT_CHARMREPODIR)
 	rsync -a -m --ignore-times --delete --exclude-from build-exclude.txt  $(CHARMDIR)/ $(CHARMREPODIR)/
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git add .
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.email "$(USER)@$(DOMAIN)"
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.name "$(USER)"
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)" --author "$(USER)@$(DOMAIN)"
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git push origin $(BUILDBRANCH)
 
 .PHONY: version-info build deploy clean check-git-build-vars git-build

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,7 @@ git-build: EXTRA_CHARM_BUILD_ARGS = --force
 git-build: build $(GIT_CHARMREPODIR)
 	rsync -a -m --ignore-times --delete --exclude-from build-exclude.txt  $(CHARMDIR)/ $(CHARMREPODIR)/
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git add .
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.email "$(USER)@$(DOMAIN)"
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.name "$(USER)"
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -c user.name="$(USER)" -c user.email="$(USER) <$(USER)@$(DOMAIN)>" -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git push origin $(BUILDBRANCH)
 
 .PHONY: version-info build deploy clean check-git-build-vars git-build

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ DISTDIR = dist
 DIST = $(DISTDIR)/.done
 GIT_HEAD_HASH = $(shell git rev-parse HEAD)
 BUILDBRANCH ?= staging
+DOMAIN ?= $(shell hostname -f)
 
 export INTERFACE_PATH
 export LAYER_PATH
@@ -95,6 +96,8 @@ git-build: EXTRA_CHARM_BUILD_ARGS = --force
 git-build: build $(GIT_CHARMREPODIR)
 	rsync -a -m --ignore-times --delete --exclude-from build-exclude.txt  $(CHARMDIR)/ $(CHARMREPODIR)/
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git add .
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.email "$(USER)@$(DOMAIN)"
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.name "$(USER)"
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git push origin $(BUILDBRANCH)
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,9 @@ git-build: EXTRA_CHARM_BUILD_ARGS = --force
 git-build: build $(GIT_CHARMREPODIR)
 	rsync -a -m --ignore-times --delete --exclude-from build-exclude.txt  $(CHARMDIR)/ $(CHARMREPODIR)/
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git add .
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)" --author "$(USER)@$(DOMAIN)"
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.email "$(USER)@$(DOMAIN)"
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.name "$(USER)"
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git push origin $(BUILDBRANCH)
 
 .PHONY: version-info build deploy clean check-git-build-vars git-build


### PR DESCRIPTION
Without this, git fails to push on the slaves because:

11:38:40 E: fatal: unable to auto-detect email address (got 'ubuntu@worker-mu-22424.(none)')

(hostname -f *may* return that (none) thing, though - not sure what it does in a slave, in my tests it would use an .lxd domain)