### PR TITLE
Rephrase instructions to be interface-agnostic.

### DIFF
--- a/src/common/components/customer-success/index.js
+++ b/src/common/components/customer-success/index.js
@@ -7,7 +7,7 @@ export default function CustomerSuccess() {
   return (
     <div className={ styles.customerSuccess }>
       <h3 data-qa="customer-success:thanks" className={ tick.green }>Payment details successfully saved, thank you!</h3>
-      <p>Proceed with your purchases in command line using <code className={ styles.code }>snap buy</code> command.</p>
+      <p>Proceed with your purchases in your software installer, or the command-line with the <code className={ styles.code }>snap buy</code> command.</p>
     </div>
   );
 }

--- a/src/common/components/welcome/index.js
+++ b/src/common/components/welcome/index.js
@@ -5,13 +5,13 @@ import styles from './welcome.css';
 export default function Welcome()  {
   return (
     <div className={ `${styles.welcome} ${styles.box}` }>
-      <h3>Buy snaps on the command line with my.ubuntu.com!</h3>
+      <h3>my.ubuntu.com allows you to set up a payment method to purchase snaps.</h3>
       <p>Setting up your my.ubuntu.com account is easy, all you need to do is:</p>
       <ul>
         <li>Log in using Ubuntu Single Sign On.</li>
         <li>Provide us your payment details.</li>
       </ul>
-      <p>Once complete, simply return to the command line and complete your purchase.</p>
+      <p>Once complete, simply use your software installer or the <i>snap</i> command-line utility to complete your purchase.</p>
     </div>
   );
 }

--- a/src/common/components/welcome/index.js
+++ b/src/common/components/welcome/index.js
@@ -11,7 +11,7 @@ export default function Welcome()  {
         <li>Log in using Ubuntu Single Sign On.</li>
         <li>Provide us your payment details.</li>
       </ul>
-      <p>Once complete, simply use your software installer or the <i>snap</i> command-line utility to complete your purchase.</p>
+      <p>Once complete, simply use your software installer or the <code className={ styles.code }>snap</code> command-line utility to complete your purchase.</p>
     </div>
   );
 }


### PR DESCRIPTION
Mentions of "the command-line" were either removed or augmented to
mention software installers (very generically since there're several and
being exhaustive is out of scope).

Fixes https://bugs.launchpad.net/snapstore/+bug/1757546.