### PR TITLE
Switch to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "stage-0", "react"],
+  "presets": ["env", "stage-0", "react"],
   "plugins": [
     "react-hot-loader/babel",
     "transform-object-rest-spread",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "babel-plugin-transform-es2015-destructuring": "^6.16.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-polyfill": "^6.16.0",
-    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.16.3",


### PR DESCRIPTION
babel-preset-es2015 now emits a warning telling us to use
babel-preset-env instead, so follow its advice.