### PR TITLE
Upgrade to react-hot-loader 4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,9 +8,6 @@
     "alphanum-sort": {
       "version": "1.0.2"
     },
-    "amdefine": {
-      "version": "1.0.1"
-    },
     "ansi-regex": {
       "version": "2.0.0"
     },
@@ -49,29 +46,6 @@
     },
     "babel-code-frame": {
       "version": "6.16.0"
-    },
-    "babel-messages": {
-      "version": "6.8.0"
-    },
-    "babel-runtime": {
-      "version": "6.18.0",
-      "dependencies": {
-        "core-js": {
-          "version": "2.4.1"
-        }
-      }
-    },
-    "babel-template": {
-      "version": "6.16.0"
-    },
-    "babel-traverse": {
-      "version": "6.19.0"
-    },
-    "babel-types": {
-      "version": "6.19.0"
-    },
-    "babylon": {
-      "version": "6.14.1"
     },
     "balanced-match": {
       "version": "0.4.2"
@@ -286,9 +260,6 @@
     "encoding": {
       "version": "0.1.12"
     },
-    "error-stack-parser": {
-      "version": "1.3.6"
-    },
     "escape-html": {
       "version": "1.0.3"
     },
@@ -332,6 +303,9 @@
     },
     "eyes": {
       "version": "0.1.8"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6"
     },
     "fastparse": {
       "version": "1.1.1"
@@ -384,10 +358,7 @@
       "version": "0.1.0"
     },
     "global": {
-      "version": "4.3.1"
-    },
-    "globals": {
-      "version": "9.14.0"
+      "version": "4.3.2"
     },
     "graceful-readlink": {
       "version": "1.0.1"
@@ -835,6 +806,20 @@
     "promise": {
       "version": "7.1.1"
     },
+    "prop-types": {
+      "version": "15.6.2",
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0"
+        },
+        "loose-envify": {
+          "version": "1.4.0"
+        },
+        "object-assign": {
+          "version": "4.1.1"
+        }
+      }
+    },
     "proxy-addr": {
       "version": "1.1.2"
     },
@@ -868,9 +853,6 @@
     "react-addons-test-utils": {
       "version": "15.4.0"
     },
-    "react-deep-force-update": {
-      "version": "2.0.1"
-    },
     "react-dom": {
       "version": "15.4.0"
     },
@@ -878,15 +860,18 @@
       "version": "3.2.2"
     },
     "react-hot-loader": {
-      "version": "3.0.0-beta.6",
+      "version": "4.3.11",
       "dependencies": {
-        "source-map": {
-          "version": "0.4.4"
+        "hoist-non-react-statics": {
+          "version": "2.5.5"
+        },
+        "shallowequal": {
+          "version": "1.1.0"
         }
       }
     },
-    "react-proxy": {
-      "version": "3.0.0-alpha.1"
+    "react-lifecycles-compat": {
+      "version": "3.0.4"
     },
     "react-redux": {
       "version": "4.4.6"
@@ -907,9 +892,6 @@
           "version": "0.9.0"
         }
       }
-    },
-    "redbox-react": {
-      "version": "1.3.3"
     },
     "reduce-css-calc": {
       "version": "1.3.0"
@@ -933,9 +915,6 @@
     },
     "regenerate": {
       "version": "1.3.2"
-    },
-    "regenerator-runtime": {
-      "version": "0.9.6"
     },
     "regexpu-core": {
       "version": "1.0.0"
@@ -1010,9 +989,6 @@
     "stack-trace": {
       "version": "0.0.9"
     },
-    "stackframe": {
-      "version": "0.3.1"
-    },
     "statsd-parser": {
       "version": "0.0.4"
     },
@@ -1039,9 +1015,6 @@
     },
     "symbol-observable": {
       "version": "1.0.4"
-    },
-    "to-fast-properties": {
-      "version": "1.0.2"
     },
     "tough-cookie": {
       "version": "2.3.2"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-helmet": "^3.1.0",
-    "react-hot-loader": "^3.0.0-beta.6",
+    "react-hot-loader": "^4.3.11",
     "react-redux": "^4.4.6",
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.6",

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -4,27 +4,7 @@ import './style/base.css';
 
 import React from 'react';
 import { render } from 'react-dom';
-import { AppContainer } from 'react-hot-loader';
 
 import Root from './root';
 
-render(
-  <AppContainer>
-    <Root />
-  </AppContainer>,
-  document.getElementById('content')
-);
-
-if (module.hot) {
-  module.hot.accept('./root', () => {
-    // If you use Webpack 2 in ES modules mode, you can
-    // use <App /> here rather than require() a <NextApp />.
-    const NextRoot = require('./root').default;
-    render(
-      <AppContainer>
-        <NextRoot />
-      </AppContainer>,
-      document.getElementById('content')
-    );
-  });
-}
+render(<Root />, document.getElementById('content'));

--- a/src/common/root.js
+++ b/src/common/root.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { hot } from 'react-hot-loader';
 import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 
@@ -23,7 +24,7 @@ history.listen((location) => {
   }
 });
 
-export default class Root extends Component {
+class Root extends Component {
   render() {
     return (
       <Provider store={store}>
@@ -32,3 +33,5 @@ export default class Root extends Component {
     );
   }
 }
+
+export default hot(module)(Root);


### PR DESCRIPTION
Among other things, this is needed in order to support a later upgrade
to babel 7; and the new API is rather more compact.